### PR TITLE
rules.mk: use long --family-suffix= option to avoid ambiguity with '-G'

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -392,7 +392,7 @@ define FontHtmlSnapshots_ =
 \
         $$$$(TTFAUTOHINT) $$$$(TTFAUTOHINT_FLAGS) \
           -w $$$$(strip $(5)) \
-          -F "-$$$$(strip $(5))" \
+          --family-suffix="-$$$$(strip $(5))" \
           -R "$$$$(word 2,$$$$+)" \
           $$$$< \
           $$$$@ \
@@ -480,7 +480,7 @@ define FontFamily_ =
       $$(call FontHtmlSnapshots, $(1), $$(s), $(3), $(4), $$(hm), $$(ff_hmodes), $$(firstword $$(ff_sty)))))
 
   $$(ff_fam): ; \
-    -mkdir $$@
+    -mkdir -p $$@
 endef
 
 


### PR DESCRIPTION
This is a minor patch which doesn't change the result of the ttfautohint command.

It is just to allow me to use the noto-hinted repository to test that my Python wrapper for ttfautohint produces identical results as the original ttfautohint executable. 

Apparently, with python's `argparse` module (used to parse command line options) the following string, which in the makefile rules for noto-hinted is meant to append the "-G" suffix to the family names: 

```
$ ttfautohint -F -G ...
```

.. is interpreted by argparse as an `-F` option without its required positional argument (hence an error) and that is followed by the `-G` option (or `--hinting-limit PPEM` in its long form).

See https://bugs.python.org/issue9334

The workaround is to use the long form with the equal sign, e.g. `--family-suffix="-G"`, which works in both python and ttfautohint native executable.

Another minor thing is the use of -p option with mkdir to prevent error message in case folder already exists.